### PR TITLE
Add scaling to producers and consumers #22 Enhance Kubernetes deployment for Kafka consumers and producer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-images:
 	docker build -t uber-producer:latest -f producer/Dockerfile .
 
 create-namespace:
-	 kubectl apply -f k8s-manifests/namespace.yml
+	 kubectl apply -f k8s-manifests/k8s-namespace.yaml
 
 add-common-env-config-map:
 	kubectl create configmap common-env \
@@ -19,8 +19,19 @@ add-postgres-secrets:
 create-resources:
 	kubectl apply -f k8s-manifests/k8s-postgres.yaml && \
 	kubectl apply -f k8s-manifests/k8s-kafka-zookeeper.yaml && \
-	kubectl apply -f k8s-manifests/k8s-consumers.yaml && \
-	kubectl apply -f k8s-manifests/k8s-producer.yaml
+	kubectl apply -f k8s-manifests/k8s-producer.yaml && \
+	helm install consumer-ride-requested ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/ride-requested.yaml && \
+	helm install consumer-ride-started ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/ride-started.yaml && \
+	helm install consumer-ride-completed ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/ride-completed.yaml && \
+	helm install consumer-location-update ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/location-update.yaml && \
+	helm install consumer-dlq ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/dlq.yaml
+
+create-consumers:
+	helm install consumer-ride-requested ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/ride-requested.yaml
+	helm install consumer-ride-started ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/ride-started.yaml
+	helm install consumer-ride-completed ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/ride-completed.yaml
+	helm install consumer-location-update ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/location-update.yaml
+	helm install consumer-dlq ./k8s-manifests/kafka-consumers-chart -f k8s-manifests/kafka-consumers-chart/consumers/dlq.yaml
 
 socat-ports:
 	# Kafka

--- a/k8s-manifests/k8s-consumers.yaml
+++ b/k8s-manifests/k8s-consumers.yaml
@@ -25,6 +25,13 @@ spec:
                 name: common-env
             - secretRef:
                 name: postgres-secret
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
 
 ---
 apiVersion: apps/v1
@@ -47,30 +54,17 @@ spec:
           image: uber-consumer:latest
           imagePullPolicy: Never
           command: ["python", "-m", "consumers.modules.consumers.consumer_ride_started"]
-          env:
-            - name: KAFKA_BROKER
-              value: kafka.uber-service.svc.cluster.local:9092
-            - name: SCHEMA_REGISTRY_URL
-              value: http://schema-registry.uber-service.svc.cluster.local:8081
-            - name: POSTGRES_HOST
-              value: postgres.uber-service.svc.cluster.local
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: postgres-secret
+              key: POSTGRES_DB
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
 
 ---
 apiVersion: apps/v1
@@ -93,30 +87,18 @@ spec:
           image: uber-consumer:latest
           imagePullPolicy: Never
           command: [ "python", "-m", "consumers.modules.consumers.consumer_ride_completed" ]
-          env:
-            - name: KAFKA_BROKER
-              value: kafka.uber-service.svc.cluster.local:9092
-            - name: SCHEMA_REGISTRY_URL
-              value: http://schema-registry.uber-service.svc.cluster.local:8081
-            - name: POSTGRES_HOST
-              value: postgres.uber-service.svc.cluster.local
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_DB
+          envFrom:
+            - configMapRef:
+                name: common-env
+            - secretRef:
+                name: postgres-secret
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
 
 ---
 apiVersion: apps/v1
@@ -139,31 +121,18 @@ spec:
           image: uber-consumer:latest
           imagePullPolicy: Never
           command: ["python", "-m", "consumers.modules.consumers.consumer_location_update"]
-          env:
-            - name: KAFKA_BROKER
-              value: kafka.uber-service.svc.cluster.local:9092
-            - name: SCHEMA_REGISTRY_URL
-              value: http://schema-registry.uber-service.svc.cluster.local:8081
-            - name: POSTGRES_HOST
-              value: postgres.uber-service.svc.cluster.local
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_DB
-
+          envFrom:
+            - configMapRef:
+                name: common-env
+            - secretRef:
+                name: postgres-secret
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -185,27 +154,145 @@ spec:
           image: uber-consumer:latest
           imagePullPolicy: Never
           command: ["python", "-m", "consumers.modules.consumers.consumer_dlq"]
-          env:
-            - name: KAFKA_BROKER
-              value: kafka.uber-service.svc.cluster.local:9092
-            - name: SCHEMA_REGISTRY_URL
-              value: http://schema-registry.uber-service.svc.cluster.local:8081
-            - name: POSTGRES_HOST
-              value: postgres.uber-service.svc.cluster.local
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_DB
+          envFrom:
+            - configMapRef:
+                name: common-env
+            - secretRef:
+                name: postgres-secret
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: consumer-ride-requested-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: consumer-ride-requested
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: consumer-ride-started-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: consumer-ride-started
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: consumer-ride-completed-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: consumer-ride-completed
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: consumer-location-update-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: consumer-location-update
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: consumer-dlq-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: consumer-dlq
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/k8s-manifests/k8s-producer.yaml
+++ b/k8s-manifests/k8s-producer.yaml
@@ -44,6 +44,9 @@ spec:
                   name: postgres-secret
                   key: POSTGRES_DB
           resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
             limits:
               memory: "256Mi"
               cpu: "250m"
@@ -65,3 +68,29 @@ spec:
       targetPort: 8888
   type: LoadBalancer
 
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kafka-producer-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kafka-producer
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/k8s-manifests/kafka-consumers-chart/Chart.yaml
+++ b/k8s-manifests/kafka-consumers-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kafka-consumer
+description: A Helm chart for deploying Kafka consumer services
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/k8s-manifests/kafka-consumers-chart/consumers/dlq.yaml
+++ b/k8s-manifests/kafka-consumers-chart/consumers/dlq.yaml
@@ -1,0 +1,1 @@
+consumerModule: consumer_dlq

--- a/k8s-manifests/kafka-consumers-chart/consumers/location-update.yaml
+++ b/k8s-manifests/kafka-consumers-chart/consumers/location-update.yaml
@@ -1,0 +1,1 @@
+consumerModule: consumer_location_update

--- a/k8s-manifests/kafka-consumers-chart/consumers/ride-completed.yaml
+++ b/k8s-manifests/kafka-consumers-chart/consumers/ride-completed.yaml
@@ -1,0 +1,1 @@
+consumerModule: consumer_ride_completed

--- a/k8s-manifests/kafka-consumers-chart/consumers/ride-requested.yaml
+++ b/k8s-manifests/kafka-consumers-chart/consumers/ride-requested.yaml
@@ -1,0 +1,1 @@
+consumerModule: consumer_ride_requested

--- a/k8s-manifests/kafka-consumers-chart/consumers/ride-started.yaml
+++ b/k8s-manifests/kafka-consumers-chart/consumers/ride-started.yaml
@@ -1,0 +1,1 @@
+consumerModule: consumer_ride_started

--- a/k8s-manifests/kafka-consumers-chart/templates/deployment.yaml
+++ b/k8s-manifests/kafka-consumers-chart/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consumer-{{ .Values.consumerModule | replace "_" "-" }}
+  namespace: uber-service
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: consumer-{{ .Values.consumerModule | replace "_" "-" }}
+  template:
+    metadata:
+      labels:
+        app: consumer-{{ .Values.consumerModule | replace "_" "-" }}
+    spec:
+      containers:
+        - name: consumer
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "consumers.modules.consumers.{{ .Values.consumerModule }}"]
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.envFrom.configMapRef }}
+            - secretRef:
+                name: {{ .Values.envFrom.secretRef }}
+          resources:
+            requests:
+              memory: {{ .Values.resources.requests.memory }}
+              cpu: {{ .Values.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.resources.limits.memory }}
+              cpu: {{ .Values.resources.limits.cpu }}

--- a/k8s-manifests/kafka-consumers-chart/templates/hpa.yaml
+++ b/k8s-manifests/kafka-consumers-chart/templates/hpa.yaml
@@ -1,0 +1,26 @@
+{{- $name := .Values.consumerModule | replace "_" "-" }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: consumer-{{ $name }}-hpa
+  namespace: uber-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: consumer-{{ $name }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}

--- a/k8s-manifests/kafka-consumers-chart/values.yaml
+++ b/k8s-manifests/kafka-consumers-chart/values.yaml
@@ -1,0 +1,27 @@
+replicaCount: 1
+
+image:
+  repository: uber-consumer
+  tag: latest
+  pullPolicy: Never
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "100m"
+  limits:
+    memory: "256Mi"
+    cpu: "250m"
+
+envFrom:
+  configMapRef: common-env
+  secretRef: postgres-secret
+
+env: []
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 75


### PR DESCRIPTION
- Update Makefile to reference new namespace file
- Add resource requests and limits for consumer deployments
- Implement Horizontal Pod Autoscalers for consumers and producer
- Create Helm chart for Kafka consumers with appropriate configurations
- Refactor environment variable handling in consumer deployments